### PR TITLE
webp preview not working

### DIFF
--- a/administrator/components/com_quantummanager/filesystem/local.php
+++ b/administrator/components/com_quantummanager/filesystem/local.php
@@ -381,7 +381,7 @@ class QuantummanagerFileSystemLocal
 				}
 
 				$uploadedFileName = $nameSafe . '.' . $nameExs;
-				$exs = explode(',', 'jpg,jpeg,png,gif');
+				$exs = explode(',', 'jpg,jpeg,png,gif,webp');
 				$type = preg_replace("/\/.*?$/isu", '', $file['type']);
 				$data['name'] = isset($data['name']) ? $data['name'] : '';
 				$path = JPATH_ROOT . DIRECTORY_SEPARATOR . QuantummanagerHelper::preparePath($data['path'], false, $data['scope']);
@@ -501,7 +501,7 @@ class QuantummanagerFileSystemLocal
 
 				}
 
-				if (in_array($exs, ['jpg', 'jpeg', 'png', 'gif']))
+				if (in_array($exs, ['jpg', 'jpeg', 'png', 'gif','webp']))
 				{
 					list($width, $height, $type, $attr) = getimagesize($filePath);
 
@@ -732,7 +732,7 @@ class QuantummanagerFileSystemLocal
 					'dateM' => $fileDate,
 				];
 
-				if(in_array(strtolower($exs), ['jpg', 'png', 'jpeg', 'gif', 'svg']))
+				if(in_array(strtolower($exs), ['jpg', 'png', 'jpeg', 'gif', 'svg','webp']))
 				{
 					$cacheSource =  JPATH_ROOT . DIRECTORY_SEPARATOR . 'cache/com_quantummanager';
 					$path = QuantummanagerHelper::preparePath($path, false, $scopeName);
@@ -983,7 +983,7 @@ class QuantummanagerFileSystemLocal
 				$nameExs = $data['exs'];
 				$nameSafe = File::makeSafe($lang->transliterate($nameSplit), ['#^\.#', '#\040#']);
 				$uploadedFileName = $nameSafe . '.' . $nameExs;
-				$exs = explode(',', 'jpg,jpeg,png,gif');
+				$exs = explode(',', 'jpg,jpeg,png,gif,webp');
 
 				if(in_array($exs, QuantummanagerHelper::$forbiddenExtensions))
 				{
@@ -1155,7 +1155,7 @@ class QuantummanagerFileSystemLocal
 			}
 		}
 
-		if(in_array($exs, ['jpg', 'jpeg', 'png', 'gif']))
+		if(in_array($exs, ['jpg', 'jpeg', 'png', 'gif','webp']))
 		{
 
 			JLoader::register('JInterventionimage', JPATH_LIBRARIES . DIRECTORY_SEPARATOR . 'jinterventionimage' . DIRECTORY_SEPARATOR . 'jinterventionimage.php');

--- a/administrator/components/com_quantummanager/helpers/image.php
+++ b/administrator/components/com_quantummanager/helpers/image.php
@@ -204,7 +204,7 @@ class QuantummanagerHelperImage
 		{
 
 			$info = pathinfo($file);
-			if(isset($info['extension']) && (!in_array(mb_strtolower($info['extension']), ['jpg', 'jpeg', 'png'])))
+			if(isset($info['extension']) && (!in_array(mb_strtolower($info['extension']), ['jpg', 'jpeg', 'png','webp'])))
 			{
 				return false;
 			}

--- a/media/com_quantummanager/js/quantumcropperjs.js
+++ b/media/com_quantummanager/js/quantumcropperjs.js
@@ -354,7 +354,7 @@ window.Quantumcropperjs = function(Filemanager, QuantumCropperjsElement, options
             name = self.file.getAttribute('data-name');
         }
 
-        if(['png', 'jpg', 'jpeg'].indexOf(exs) === -1) {
+        if(['png', 'jpg', 'jpeg','webp'].indexOf(exs) === -1) {
             return;
         }
 
@@ -541,7 +541,7 @@ window.Quantumcropperjs = function(Filemanager, QuantumCropperjsElement, options
             return;
         }
 
-        if(['png', 'jpg', 'jpeg'].indexOf(exs) === -1) {
+        if(['png', 'jpg', 'jpeg','webp'].indexOf(exs) === -1) {
             fm.Quantumtoolbar.buttonsList['cropperjsEdit'].classList.add('btn-hide');
             return;
         }
@@ -573,7 +573,7 @@ window.Quantumcropperjs = function(Filemanager, QuantumCropperjsElement, options
                 Filemanager.Quantumcropperjs.nameFile = nameFile;
                 Filemanager.Quantumcropperjs.file = '';
 
-                if(['png', 'jpg', 'jpeg'].indexOf(exs) === -1) {
+                if(['png', 'jpg', 'jpeg','webp'].indexOf(exs) === -1) {
                     return;
                 }
 
@@ -586,7 +586,7 @@ window.Quantumcropperjs = function(Filemanager, QuantumCropperjsElement, options
         return [
             {
                 writeable: 1,
-                fileExs: ['png', 'jpg', 'jpeg'],
+                fileExs: ['png', 'jpg', 'jpeg','webp'],
                 type: 'normal',
                 label: QuantumviewfilesLang.buttonEdit,
                 tip: '',

--- a/media/com_quantummanager/js/quantumupload.js
+++ b/media/com_quantummanager/js/quantumupload.js
@@ -34,7 +34,7 @@ window.Qantumupload = function(Filemanager, UploadElement, options) {
         this.dropArea = UploadElement.closest(".quantummanager");
         this.dropAreaInput = UploadElement.querySelector('.drop-area');
         this.inputFileAll = UploadElement.querySelectorAll(".fileElem");
-        this.exs = ['jpg', 'jpeg', 'png', 'gif'];
+        this.exs = ['jpg', 'jpeg', 'png', 'gif','webp'];
         this.path = options.directory;
         Filemanager.element.setAttribute('data-drag-drop-title', QuantumuploadLang.dragDrop);
 

--- a/media/com_quantummanager/js/quantumviewfiles.js
+++ b/media/com_quantummanager/js/quantumviewfiles.js
@@ -232,7 +232,7 @@ window.Quantumviewfiles = function(Filemanager, ViewfilesElement, options) {
     this.IdsButtonForFile = [
         {
             'id': 'viewfilesWatermark',
-            'exs': ['png', 'jpg', 'jpeg'],
+            'exs': ['png', 'jpg', 'jpeg','webp'],
             'for': 'file',
             'count': 'some'
         },
@@ -1553,7 +1553,7 @@ window.Quantumviewfiles = function(Filemanager, ViewfilesElement, options) {
             let objectAll = self.ds.getSelection();
             let size = 0;
             let imgs = '';
-            let exsImage = ['jpg', 'png', 'svg', 'jpeg', 'gif'];
+            let exsImage = ['jpg', 'png', 'svg', 'jpeg', 'gif','webp'];
             let objectOnlyFiles = true;
 
             for (let i = objectAll.length - 1; i >= 0; i--) {
@@ -1950,7 +1950,7 @@ window.Quantumviewfiles = function(Filemanager, ViewfilesElement, options) {
                 let fileName = filesAll[i].getAttribute('data-name');
                 let fileExs = filesAll[i].getAttribute('data-exs');
                 let filePreview = filesAll[i].querySelector('.file-exs');
-                let exsImage = ['jpg', 'png', 'svg', 'jpeg', 'gif'];
+                let exsImage = ['jpg', 'png', 'svg', 'jpeg', 'gif','webp'];
                 let fields = filesAll[i].querySelector('.fields');
 
                 if(fields !== null) {
@@ -2057,7 +2057,7 @@ window.Quantumviewfiles = function(Filemanager, ViewfilesElement, options) {
             }
         }
 
-        if(['png', 'jpg', 'jpeg'].indexOf(exs) !== -1) {
+        if(['png', 'jpg', 'jpeg','webp'].indexOf(exs) !== -1) {
             if(fm.Quantumtoolbar !== undefined && fm.Quantumtoolbar.buttonsList['viewfilesWatermark'] !== undefined) {
                 fm.Quantumtoolbar.buttonsList['viewfilesWatermark'].classList.remove('btn-hide');
             }


### PR DESCRIPTION
In Quantum Manager, if a directory contains webp images, a webp png is displayed.

![image](https://user-images.githubusercontent.com/19435246/89122157-6668a000-d4c5-11ea-9610-9c497d6dca5d.png)

After applying this PR, webp image preview shows the correct image.
![image](https://user-images.githubusercontent.com/19435246/89122191-ab8cd200-d4c5-11ea-8221-31b46996f49c.png)

This PR fixes also missing webp handling (upload image, crop,...)

